### PR TITLE
Bump to albacore v3 to support .net core projects

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
 source "http://rubygems.org"
 
 # gem 'albacore', :git => 'https://github.com/Albacore/albacore.git', :branch => 'clean_slate'
-gem 'albacore', '~> 2.0.0'
+gem 'albacore', '~> 3.0.0'


### PR DESCRIPTION
As mentioned in https://github.com/haf/DotNetZip.Semverd/pull/112#issuecomment-387726815 to ensure the CI pipeline is able to output .net standard projects and hopefully completing the .net standard support.

Notably I haven't been apart of the effort in #103 so unsure if this will actually output, but the comments on the prior PR suggest this should in theory be quite easy.

I do not have build infrastructure myself to ensure this is actually going to work, but hoping the PR will kick off a CI build that'll output the artefacts we're all hoping for :-) 